### PR TITLE
Implemented timer for ToaruOS

### DIFF
--- a/configure
+++ b/configure
@@ -21718,7 +21718,14 @@ case "$host" in
 
         $as_echo "#define SDL_VIDEO_DRIVER_TOARU 1" >>confdefs.h
         SOURCES="$SOURCES $srcdir/src/video/toaru/*.c"
-        EXTRA_LDFLAGS="$EXTRA_LDFLGAGS -ltoaru_decorations -ltoaru_menu -ltoaru_yutani -ltoaru_graphics"
+
+        if test x$enable_timers = xyes; then
+            $as_echo "#define SDL_TIMER_UNIX 1" >>confdefs.h
+            SOURCES="$SOURCES $srcdir/src/timer/unix/*.c"
+            have_timers=yes
+        fi
+
+        EXTRA_LDFLAGS="$EXTRA_LDFLGAGS -ltoaru_decorations -ltoaru_menu -ltoaru_yutani -ltoaru_graphics -ltoaru_hashmap"
         ;;
     *-*-cygwin* | *-*-mingw32*)
         ARCH=win32

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -46,7 +46,7 @@
 #include <pth.h>
 #endif
 
-#if SDL_THREADS_DISABLED
+#if SDL_THREADS_DISABLED && !defined(toaru)
 #define USE_ITIMER
 #endif
 
@@ -87,6 +87,7 @@ Uint32 SDL_GetTicks (void)
 
 void SDL_Delay (Uint32 ms)
 {
+#ifndef toaru
 #if SDL_THREAD_PTH
 	pth_time_t tv;
 	tv.tv_sec  =  ms/1000;
@@ -132,6 +133,9 @@ void SDL_Delay (Uint32 ms)
 #endif /* HAVE_NANOSLEEP */
 	} while ( was_error && (errno == EINTR) );
 #endif /* SDL_THREAD_PTH */
+#else
+	usleep(ms*1000);
+#endif /* toaru*/
 }
 
 #ifdef USE_ITIMER


### PR DESCRIPTION
- Implemented a timer using `usleep()` ;
- Added `toaru_hashmap` library, without it there was a linking error.